### PR TITLE
Upgrade to using Rocket 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ unic-ucd = "0.6.0"
 # unic-ucd-category = "0.6.0"
 # lazy_static = "0.2.8"
 # regex = "0.2.2"
-
-
+[dev-dependencies]
+serde_json = "1.0"
+serde = {version = "1.0", features = ["derive"]}
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "rocket-auth-login"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Andrew Prindle <prindle.andrew@gmail.com>"]
 
 description = "Login and authentication for rocket web apps.  This crate provides functions to process login forms and to deal with private cookies easily."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ exclude = ["database", "examples/**"]
 
 [dependencies]
 htmlescape = "0.3.1"
-rocket = "0.3.*"
-rocket_codegen = "0.3.*"
+rocket = "0.4.*"
 unic-ucd = "0.6.0"
 # unic-ucd-category = "0.6.0"
 # lazy_static = "0.2.8"

--- a/examples/basic_example/Cargo.toml
+++ b/examples/basic_example/Cargo.toml
@@ -6,14 +6,14 @@ publish = false
 
 [dependencies]
 htmlescape = "0.3.1"
-lazy_static = "0.2.8"
-regex = "0.2.2"
+lazy_static = "1.2"
+regex = "1.1"
 rmp-serde = "0.13.7"
-rocket = "0.3.3"
-rocket_codegen = "0.3.3"
-serde_json = "1.0.2"
-serde = "1.0.11"
-serde_derive = "1.0.11"
+rocket = "0.4"
+
+serde_json = "1.0"
+serde = {version="1.0", features=["derive"]}
+
 time = "0.1"
 titlecase = "0.10.0"
 

--- a/examples/basic_example/src/main.rs
+++ b/examples/basic_example/src/main.rs
@@ -1,18 +1,15 @@
+#![feature(proc_macro_hygiene, decl_macro)]
 
-#![feature(custom_derive)]
-#![feature(plugin)]
-#![plugin(rocket_codegen)]
+#[macro_use] extern crate rocket;
 
-extern crate rocket;
-extern crate serde;
-#[macro_use] extern crate serde_derive;
+#[macro_use] extern crate serde;
 extern crate rmp_serde as rmps;
 extern crate regex;
 extern crate time;
 extern crate titlecase;
 extern crate htmlescape;
 #[allow(unused_imports)] #[macro_use] extern crate serde_json;
-// #[macro_use] extern crate lazy_static;
+
 extern crate rocket_auth_login as auth;
 
 use auth::authorization::*;

--- a/examples/database_example/Cargo.toml
+++ b/examples/database_example/Cargo.toml
@@ -6,17 +6,16 @@ publish = false
 
 [dependencies]
 argon2rs = "0.2.5"
-dotenv = "0.10.1"
+dotenv = "0.13"
 htmlescape = "0.3.1"
-rand = "0.3.18"
-lazy_static = "0.2.8"
-regex = "0.2.2"
+rand = "0.6"
+lazy_static = "1.2"
+regex = "1.1"
 rmp-serde = "0.13.7"
-rocket = "0.3.3"
-rocket_codegen = "0.3.3"
-serde_json = "1.0.2"
-serde = "1.0.11"
-serde_derive = "1.0.11"
+rocket = "0.4"
+rocket_codegen = "0.4"
+serde_json = "1.0"
+serde = {version="1.0", features=["derive"]}
 time = "0.1"
 titlecase = "0.10.0"
 postgres = { version = "0.15.1", features = ["with-chrono"] }

--- a/examples/database_example/src/main.rs
+++ b/examples/database_example/src/main.rs
@@ -1,11 +1,8 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+#[macro_use] extern crate rocket;
 
-#![feature(custom_derive)]
-#![feature(plugin)]
-#![plugin(rocket_codegen)]
+#[macro_use] extern crate serde;
 
-extern crate rocket;
-extern crate serde;
-#[macro_use] extern crate serde_derive;
 extern crate rmp_serde as rmps;
 extern crate regex;
 extern crate time;

--- a/examples/tls_example/Cargo.toml
+++ b/examples/tls_example/Cargo.toml
@@ -6,18 +6,16 @@ publish = false
 
 [dependencies]
 argon2rs = "0.2.5"
-dotenv = "0.10.1"
+dotenv = "0.13"
 htmlescape = "0.3.1"
-rand = "0.3.18"
-lazy_static = "0.2.8"
-regex = "0.2.2"
+rand = "0.6"
+lazy_static = "1.2"
+regex = "1.1"
 rmp-serde = "0.13.7"
-# rocket = "0.3.3"
-# rocket = { version = "0.3.3", features = ["tls"] }
-rocket_codegen = "0.3.3"
-serde_json = "1.0.2"
-serde = "1.0.11"
-serde_derive = "1.0.11"
+rocket = {version="0.4", features=["tls"]}
+serde_json = "1.0"
+serde = {version="1.0", features=["derive"] }
+
 time = "0.1"
 titlecase = "0.10.0"
 postgres = { version = "0.15.1", features = ["with-chrono"] }
@@ -27,9 +25,4 @@ r2d2_postgres = "0.13.0"
 
 rocket-auth-login = { path = "../../" }
 
-
-[dependencies.rocket]
-version = "=0.3.3"
-# default-features = false
-features = ["tls"]
 

--- a/examples/tls_example/src/administrator.rs
+++ b/examples/tls_example/src/administrator.rs
@@ -139,7 +139,7 @@ impl AuthorizeForm for AdministratorForm {
     /// Define a custom flash_redirect() method that overrides the default
     /// implementation in authorization::AuthorizeForm trait.
     /// This allows the cookie to be made secure
-    fn flash_redirect(&self, ok_redir: &str, err_redir: &str, cookies: &mut Cookies) -> Result<Redirect, Flash<Redirect>> {
+    fn flash_redirect(&self, ok_redir: impl Into<String>, err_redir: impl Into<String>, cookies: &mut Cookies) -> Result<Redirect, Flash<Redirect>> {
         match self.authenticate() {
             Ok(cooky) => {
                 let cid = Self::cookie_id();
@@ -149,15 +149,15 @@ impl AuthorizeForm for AdministratorForm {
                         // .secure(true)
                         .finish()
                 );
-                Ok(Redirect::to(ok_redir))
+                Ok(Redirect::to(ok_redir.into()))
             },
             Err(fail) => {
-                let mut furl = String::from(err_redir);
+                let mut furl = err_redir.into();
                 if &fail.user != "" {
                     let furl_qrystr = Self::fail_url(&fail.user);
                     furl.push_str(&furl_qrystr);
                 }
-                Err( Flash::error(Redirect::to(&furl), &fail.msg) )
+                Err( Flash::error(Redirect::to(furl), &fail.msg) )
             },
         }
     }

--- a/examples/tls_example/src/main.rs
+++ b/examples/tls_example/src/main.rs
@@ -1,11 +1,8 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+#[macro_use] extern crate rocket;
 
-#![feature(custom_derive)]
-#![feature(plugin, decl_marco)]
-#![plugin(rocket_codegen)]
+#[macro_use] extern crate serde;
 
-extern crate rocket;
-extern crate serde;
-#[macro_use] extern crate serde_derive;
 extern crate rmp_serde as rmps;
 extern crate regex;
 extern crate time;

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -1,8 +1,8 @@
 
 use rocket::{Request, Outcome};
 use rocket::response::{Redirect, Flash};
-use rocket::request::{FromRequest, FromForm, FormItems, FormItem};
-use rocket::http::{Cookie, Cookies};
+use rocket::request::{FromRequest, FromForm, FormItems, FormItem, FromFormValue};
+use rocket::http::{Cookie, Cookies, RawStr};
 
 use std::collections::HashMap;
 use std::marker::Sized;
@@ -534,5 +534,13 @@ impl<'f> FromForm<'f> for UserQuery {
             }
         }
         Ok(UserQuery { user: name })
+    }
+}
+
+impl<'f> FromFormValue<'f> for UserQuery {
+    type Error = &'static str;
+    
+    fn from_form_value(form_value: &'f RawStr) -> Result<Self, Self::Error> {
+        Ok(UserQuery { user: sanitize(&form_value.url_decode().unwrap_or(String::new())) })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,11 +31,10 @@
 
 */
 
-#![feature(custom_derive)]
-#![feature(plugin)]
-#![plugin(rocket_codegen)]
+#![feature(proc_macro_hygiene, decl_macro)]
 
-extern crate rocket;
+#[macro_use] extern crate rocket;
+
 extern crate unic_ucd;
 // #[allow(unused_imports)] extern crate regex;
 // #[allow(unused_imports)] #[macro_use] extern crate lazy_static;


### PR DESCRIPTION
Changes of note:
  1. Now using Rocket 0.4. This didn't require too many changes in itself.
  1. In addition to bumping things to Rocket 0.4, I've updated some other dependencies. We can avoid importing `serde_derive` by using the `"derive"` feature of `serde`.
  2. `flash_redirect` now takes `impl Into<String>` instead of `&str` since we need to convert it to a `String` in both paths, and if the user is using the new `uri!{ route: params}.to_string()`, they have an owned string anyway.
  3. There's now an implementation of `FromFormValue` for `UserQuery`, which was necessary for (at least) the basic example to work, with `UserQuery` as a query parm.
  4. It looks like the doc tests never worked? They do now, though it feels a bit hackish.
  5. I bumped the version to 0.3